### PR TITLE
Build fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -432,7 +432,11 @@ AS_IF([test "x$enable_purple" != xno],
 				 [dnl libpurple supports raw data RTP connections
 				  ac_have_xdata=yes]
 			 )
-			])
+			],
+			[AS_IF([test "x$with_vv" = xyes], dnl explicitly requested by user
+				[AC_ERROR([Voice and video support explicitly requested, but not available])]
+			 )]
+		 )
 
 		 CFLAGS="$ac_save_CFLAGS"
 		 LIBS="$ac_save_LIBS"])])

--- a/configure.ac
+++ b/configure.ac
@@ -499,7 +499,18 @@ PKG_CHECK_MODULES(FREERDP, [freerdp-shadow2],
 
 AM_CONDITIONAL(SIPE_FREERDP, [test "x$ac_enable_freerdp" = xyes])
 AS_IF([test "x$ac_enable_freerdp" = xyes],
-	[AC_DEFINE(HAVE_FREERDP, 1, [Define to 1 if you have FreeRDP headers.])])
+	[AC_DEFINE(HAVE_FREERDP, 1, [Define to 1 if you have FreeRDP headers.])
+	 ac_save_CFLAGS="$CFLAGS"
+	 ac_save_LDFLAGS="$LDFLAGS"
+	 CFLAGS="$CFLAGS $FREERDP_CFLAGS"
+	 LDFLAGS="$LDFLAGS $FREERDP_LIBS"
+	 AC_CHECK_FUNC([shadow_subsystem_set_entry_builtin],
+		     [AC_DEFINE(HAVE_FREERDP_SHADOW_SUBSYSTEM_SET_ENTRY_BUILTIN, 1, [Define to 1 if libfreerdp-shadow has shadow_subsystem_set_entry_builtin])],
+		     [])
+	 CFLAGS="$ac_save_CFLAGS"
+	 LDFLAGS="$ac_save_LDFLAGS"]
+)
+
 
 dnl these code parts rely on interfaces that require GValueArray. This
 dnl type has been declared "deprectated" in glib-2.0 >= 2.32.0, but there

--- a/src/core/sipe-applicationsharing.c
+++ b/src/core/sipe-applicationsharing.c
@@ -819,13 +819,21 @@ monitor_selected_cb(struct sipe_core_private *sipe_private, gchar *who,
 	g_free(who);
 }
 
+#ifndef HAVE_FREERDP_SHADOW_SUBSYSTEM_SET_ENTRY_BUILTIN
+extern int X11_ShadowSubsystemEntry(RDP_SHADOW_ENTRY_POINTS* pEntryPoints);
+#endif
+
 static void
 present_monitor_choice(struct sipe_core_public *sipe_public, const gchar *who)
 {
 	MONITOR_DEF monitors[16];
 	int monitor_count;
 
+#ifdef HAVE_FREERDP_SHADOW_SUBSYSTEM_SET_ENTRY_BUILTIN
 	shadow_subsystem_set_entry_builtin("X11");
+#else
+	shadow_subsystem_set_entry(X11_ShadowSubsystemEntry);
+#endif
 	monitor_count = shadow_enum_monitors(monitors, 16);
 
 	if (monitor_count == 1) {

--- a/src/core/sipe-buddy.c
+++ b/src/core/sipe-buddy.c
@@ -2209,6 +2209,7 @@ static struct sipe_backend_buddy_menu *buddy_menu_phone(struct sipe_core_public 
 	return(menu);
 }
 
+#ifdef HAVE_FREERDP
 static struct sipe_backend_buddy_menu *buddy_menu_share_desktop(struct sipe_core_public *sipe_public,
 								struct sipe_backend_buddy_menu *menu,
 								const gchar *buddy_name)
@@ -2233,7 +2234,6 @@ static struct sipe_backend_buddy_menu *buddy_menu_share_desktop(struct sipe_core
 		}
 	}
 
-#ifdef HAVE_FREERDP
 	if (appshare) {
 		if (sipe_core_applicationsharing_get_remote_control(appshare)) {
 			menu = sipe_backend_buddy_menu_add(sipe_public, menu,
@@ -2252,10 +2252,10 @@ static struct sipe_backend_buddy_menu *buddy_menu_share_desktop(struct sipe_core
 				SIPE_BUDDY_MENU_SHARE_APPLICATION,
 				NULL);
 	}
-#endif
 
 	return menu;
 }
+#endif
 
 struct sipe_backend_buddy_menu *sipe_core_buddy_create_menu(struct sipe_core_public *sipe_public,
 							    const gchar *buddy_name,
@@ -2386,7 +2386,9 @@ struct sipe_backend_buddy_menu *sipe_core_buddy_create_menu(struct sipe_core_pub
 		}
 	}
 
+#ifdef HAVE_FREERDP
 	menu = buddy_menu_share_desktop(sipe_public, menu, buddy_name);
+#endif
 
 	/* access level control */
 	if (SIPE_CORE_PRIVATE_FLAG_IS(OCS2007))

--- a/src/core/sipe-conf.c
+++ b/src/core/sipe-conf.c
@@ -1123,6 +1123,7 @@ ask_accept_voice_conference(struct sipe_core_private *sipe_private,
 	g_free(question);
 }
 
+#ifdef HAVE_VV
 static void
 presentation_accepted_cb(struct sipe_core_private *sipe_private,
 			 struct conf_accept_ctx *ctx)
@@ -1142,6 +1143,7 @@ ask_accept_conf_presentation(struct sipe_core_private *sipe_private,
 			      presentation_accepted_cb, NULL,
 			      chat_session);
 }
+#endif
 
 void
 process_incoming_invite_conf(struct sipe_core_private *sipe_private,
@@ -1235,8 +1237,10 @@ sipe_process_conference(struct sipe_core_private *sipe_private,
 	const gchar *focus_uri;
 	struct sip_session *session;
 	gboolean just_joined = FALSE;
+#ifdef HAVE_VV
 	gboolean audio_was_added = FALSE;
 	gboolean presentation_was_added = FALSE;
+#endif
 
 	if (msg->response != 0 && msg->response != 200) return;
 
@@ -1357,15 +1361,14 @@ sipe_process_conference(struct sipe_core_private *sipe_private,
 						sipe_backend_chat_operator(session->chat_session->backend,
 									   user_uri);
 					}
-				} else if (sipe_strequal("audio-video", session_type)) {
 #ifdef HAVE_VV
+				} else if (sipe_strequal("audio-video", session_type)) {
 					if (!session->is_call)
 						audio_was_added = TRUE;
 					process_conference_av_endpoint(endpoint,
 								       user_uri,
 								       self,
 								       session);
-#endif
 				} else if (sipe_strequal("applicationsharing", session_type)) {
 					if (!sipe_core_conf_get_presentation_media_call(SIPE_CORE_PUBLIC, session->chat_session) &&
 					    !sipe_strequal(user_uri, self)) {
@@ -1379,6 +1382,7 @@ sipe_process_conference(struct sipe_core_private *sipe_private,
 						g_free(media_state);
 						g_free(status);
 					}
+#endif
 				}
 			}
 			if (!is_in_im_mcu) {

--- a/src/purple/purple-chat.c
+++ b/src/purple/purple-chat.c
@@ -306,8 +306,9 @@ sipe_purple_chat_menu(PurpleChat *chat)
 
 	if (conv) {
 		PurpleMenuAction *act = NULL;
+#ifdef HAVE_VV
 		struct sipe_media_call *call = NULL;
-
+#endif
 		SIPE_DEBUG_INFO("sipe_purple_chat_menu: %p", conv);
 
 		switch (sipe_core_chat_lock_status(PURPLE_CONV_TO_SIPE_CORE_PUBLIC,


### PR DESCRIPTION
Fix the !HAVE_VV build... and give me a way to deliberately break it again because actually I don't _want_ a build without voice&video to ever succeed.

Also add a configure check for the FreeRDP2 snapshot that was shipped in Fedora 24, to fix the build there without additional patches.
