### PR TITLE
Tell GCC we intend to fall through

### DIFF
--- a/src/core/sipe-media.c
+++ b/src/core/sipe-media.c
@@ -1934,6 +1934,7 @@ process_invite_call_response(struct sipe_core_private *sipe_private,
 				}
 				// Break intentionally omitted
 			}
+			/* FALLTHRU */
 			default:
 				title = _("Error occurred");
 				g_string_append(desc, _("Unable to establish a call"));


### PR DESCRIPTION
Fixes #160

GCC 7 adds implicit fall-through detection so we need to tell it when
we intend a fall-through to happen.